### PR TITLE
Cria endpoint de editar baralho (PUT)

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/acobaugh/osrelease v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/oleiade/reflections v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -268,6 +268,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/oleiade/reflections v1.0.1 h1:D1XO3LVEYroYskEsoSiGItp9RUxG6jWnCVvrqH0HHQM=
+github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/server/src/routes/deck_routes.go
+++ b/server/src/routes/deck_routes.go
@@ -15,6 +15,7 @@ func DeckRoutes(routerGroup *gin.RouterGroup) {
 	deck.GET("", controllers.GetDecks)
 	deck.POST("", controllers.PostDecks)
 	deck.DELETE("/:id", controllers.DeleteDeck)
+	deck.PUT("/:id", controllers.PutDeck)
 	deck.POST("/copy/:id", controllers.CopyDeck)
 }
 
@@ -24,5 +25,6 @@ func DeckRoutesTest(routerGroup *gin.RouterGroup) {
 	deck.GET("", controllers.GetDecks)
 	deck.POST("", controllers.PostDecks)
 	deck.DELETE("/:id", controllers.DeleteDeck)
+	deck.PUT("/:id", controllers.PutDeck)
 	deck.POST("/copy/:id", controllers.CopyDeck)
 }

--- a/server/src/utils/file_utils.go
+++ b/server/src/utils/file_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 	"path/filepath"
 )
 
@@ -20,4 +21,13 @@ func UploadFile(file []byte, filename string) (string, error) {
 	}
 
 	return imageFilepath, nil
+}
+
+func RemoveFile(onlinePath string) error {
+	filename := strings.Replace(onlinePath, "http://localhost:8080/image/", "", -1)
+	absPath, _ := filepath.Abs(ImagesDir + filename)
+
+	err := os.Remove(absPath)
+
+	return err
 }

--- a/server/src/utils/file_utils.go
+++ b/server/src/utils/file_utils.go
@@ -24,7 +24,7 @@ func UploadFile(file []byte, filename string) (string, error) {
 }
 
 func RemoveFile(onlinePath string) error {
-	filename := strings.Replace(onlinePath, "http://localhost:8080/image/", "", -1)
+	filename := strings.Replace(onlinePath, ImagesRoute + "/", "", -1)
 	absPath, _ := filepath.Abs(ImagesDir + filename)
 
 	err := os.Remove(absPath)


### PR DESCRIPTION
Objetivo é facilitar a edição de um baralho quanto à adição e remoção de imagens.

- Foi ajustado o controller de post de baralho: campo do formulário deve conter o id do card correspondente à imagem (não mais a ordem)
- Criação do endpoint de put de baralho: Para não precisar ficar enviando informação desnecessária no servidor por causa de uma pequena moficação, além de ficar mais fácil remover uma imagem (não estava sendo tratado antes)