### PR TITLE
Implementa comunicação com a api

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,12 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:kiwi/kiwi.dart';
 import 'package:memento_studio/src/utils.dart';
 
+import 'package:logging/logging.dart';
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await injectDependencies();
 
+  _setupLogging();
+
   runApp(const MementoStudio());
+}
+
+void _setupLogging() {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen((rec) {
+    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+  });
 }
 
 class MementoStudio extends StatefulWidget {

--- a/app/lib/src/datasource/api/api.dart
+++ b/app/lib/src/datasource/api/api.dart
@@ -1,7 +1,9 @@
 import 'package:chopper/chopper.dart';
 import 'package:memento_studio/src/datasource/api/user_api.dart';
+import '../../entities/api/deck_reference.dart';
 import '../../entities/api/user.dart';
 import 'deck_api.dart';
+import 'deck_reference_api.dart';
 import 'json_converter.dart';
 import 'package:memento_studio/src/entities/api/deck.dart';
 
@@ -11,7 +13,8 @@ class Api {
       baseUrl: "http://localhost:8080/api",
       services: [
         DeckApi.create(),
-        UserApi.create()
+        UserApi.create(),
+        DeckReferenceApi.create()
         // Colocar os outros (user, referencia) aqui também
       ],
       interceptors: [
@@ -20,6 +23,7 @@ class Api {
       converter: JsonToTypeConverter({
             Deck: (jsonData) => Deck.fromJson(jsonData),
             User: (jsonData) => User.fromJson(jsonData),
+            DeckReference: (jsonData) => DeckReference.fromJson(jsonData),
             Map<String, dynamic>: (jsonData) => jsonData
           }
         )

--- a/app/lib/src/datasource/api/api.dart
+++ b/app/lib/src/datasource/api/api.dart
@@ -18,7 +18,8 @@ class Api {
         // Colocar os outros (user, referencia) aqui também
       ],
       interceptors: [
-        HttpLoggingInterceptor()
+        HttpLoggingInterceptor(),
+        const HeadersInterceptor({"Authorization": "Bearer "}) // TODO: adicionar token
       ],
       converter: JsonToTypeConverter({
             Deck: (jsonData) => Deck.fromJson(jsonData),

--- a/app/lib/src/datasource/api/api.dart
+++ b/app/lib/src/datasource/api/api.dart
@@ -1,4 +1,6 @@
 import 'package:chopper/chopper.dart';
+import 'package:memento_studio/src/datasource/api/user_api.dart';
+import '../../entities/api/user.dart';
 import 'deck_api.dart';
 import 'json_converter.dart';
 import 'package:memento_studio/src/entities/api/deck.dart';
@@ -8,7 +10,8 @@ class Api {
     return ChopperClient(
       baseUrl: "http://localhost:8080/api",
       services: [
-        DeckApi.create()
+        DeckApi.create(),
+        UserApi.create()
         // Colocar os outros (user, referencia) aqui também
       ],
       interceptors: [
@@ -16,6 +19,7 @@ class Api {
       ],
       converter: JsonToTypeConverter({
             Deck: (jsonData) => Deck.fromJson(jsonData),
+            User: (jsonData) => User.fromJson(jsonData),
             Map<String, dynamic>: (jsonData) => jsonData
           }
         )

--- a/app/lib/src/datasource/api/api.dart
+++ b/app/lib/src/datasource/api/api.dart
@@ -1,0 +1,23 @@
+import 'package:chopper/chopper.dart';
+import 'deck_api.dart';
+import 'json_converter.dart';
+import 'package:memento_studio/src/entities/api/deck.dart';
+
+class Api {
+  static ChopperClient createInstance(){
+    return ChopperClient(
+      baseUrl: "http://localhost:8080/api",
+      services: [
+        DeckApi.create()
+        // Colocar os outros (user, referencia) aqui também
+      ],
+      interceptors: [
+        HttpLoggingInterceptor()
+      ],
+      converter: JsonToTypeConverter({
+            Deck: (jsonData) => Deck.fromJson(jsonData)
+          }
+        )
+    );
+  }
+}

--- a/app/lib/src/datasource/api/api.dart
+++ b/app/lib/src/datasource/api/api.dart
@@ -15,7 +15,8 @@ class Api {
         HttpLoggingInterceptor()
       ],
       converter: JsonToTypeConverter({
-            Deck: (jsonData) => Deck.fromJson(jsonData)
+            Deck: (jsonData) => Deck.fromJson(jsonData),
+            Map<String, dynamic>: (jsonData) => jsonData
           }
         )
     );

--- a/app/lib/src/datasource/api/deck_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_api.chopper.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deck_api.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+class _$DeckApi extends DeckApi {
+  _$DeckApi([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = DeckApi;
+
+  @override
+  Future<Response<List<Deck>>> getDecks(Map<String, int> pagination) {
+    final $url = '/decks';
+    final $body = pagination;
+    final $request = Request('GET', $url, client.baseUrl, body: $body);
+    return client.send<List<Deck>, Deck>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postDeck(Deck deck, dynamic files) {
+    final $url = '/decks';
+    final $headers = {
+      'Content-Type': 'multipart/form-data',
+    };
+
+    final $parts = <PartValue>[PartValue<Deck>('deck', deck)];
+    $parts.addAll(files);
+    final $request = Request('POST', $url, client.baseUrl,
+        parts: $parts, multipart: true, headers: $headers);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> putDeck(String deckId, Deck deck, dynamic files) {
+    final $url = '/decks/${deckId}';
+    final $headers = {
+      'Content-Type': 'multipart/form-data',
+    };
+
+    final $parts = <PartValue>[PartValue<Deck>('deck', deck)];
+    $parts.addAll(files);
+    final $request = Request('POST', $url, client.baseUrl,
+        parts: $parts, multipart: true, headers: $headers);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteDeck(String deckId) {
+    final $url = '/decks/${deckId}';
+    final $request = Request('DELETE', $url, client.baseUrl);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> copyDeck(String deckId) {
+    final $url = '/decks/${deckId}';
+    final $request = Request('POST', $url, client.baseUrl);
+    return client.send<dynamic, dynamic>($request);
+  }
+}

--- a/app/lib/src/datasource/api/deck_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_api.chopper.dart
@@ -39,17 +39,18 @@ class _$DeckApi extends DeckApi {
   }
 
   @override
-  Future<Response<dynamic>> putDeck(String deckId, Deck deck, dynamic files) {
+  Future<Response<Deck>> putDeck(
+      String deckId, String deckUpdates, dynamic images) {
     final $url = '/decks/${deckId}';
     final $headers = {
       'Content-Type': 'multipart/form-data',
     };
 
-    final $parts = <PartValue>[PartValue<Deck>('deck', deck)];
-    $parts.addAll(files);
+    final $parts = <PartValue>[PartValue<String>('deck', deckUpdates)];
+    $parts.addAll(images);
     final $request = Request('PUT', $url, client.baseUrl,
         parts: $parts, multipart: true, headers: $headers);
-    return client.send<dynamic, dynamic>($request);
+    return client.send<Deck, Deck>($request);
   }
 
   @override

--- a/app/lib/src/datasource/api/deck_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_api.chopper.dart
@@ -25,17 +25,17 @@ class _$DeckApi extends DeckApi {
   }
 
   @override
-  Future<Response<dynamic>> postDeck(Deck deck, dynamic files) {
+  Future<Response<Deck>> postDeck(dynamic deck, dynamic images) {
     final $url = '/decks';
     final $headers = {
       'Content-Type': 'multipart/form-data',
     };
 
-    final $parts = <PartValue>[PartValue<Deck>('deck', deck)];
-    $parts.addAll(files);
+    final $parts = <PartValue>[PartValue<dynamic>('deck', deck)];
+    $parts.addAll(images);
     final $request = Request('POST', $url, client.baseUrl,
         parts: $parts, multipart: true, headers: $headers);
-    return client.send<dynamic, dynamic>($request);
+    return client.send<Deck, Deck>($request);
   }
 
   @override
@@ -47,7 +47,7 @@ class _$DeckApi extends DeckApi {
 
     final $parts = <PartValue>[PartValue<Deck>('deck', deck)];
     $parts.addAll(files);
-    final $request = Request('POST', $url, client.baseUrl,
+    final $request = Request('PUT', $url, client.baseUrl,
         parts: $parts, multipart: true, headers: $headers);
     return client.send<dynamic, dynamic>($request);
   }

--- a/app/lib/src/datasource/api/deck_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_api.chopper.dart
@@ -54,10 +54,10 @@ class _$DeckApi extends DeckApi {
   }
 
   @override
-  Future<Response<dynamic>> deleteDeck(String deckId) {
+  Future<Response<Map<String, dynamic>>> deleteDeck(String deckId) {
     final $url = '/decks/${deckId}';
     final $request = Request('DELETE', $url, client.baseUrl);
-    return client.send<dynamic, dynamic>($request);
+    return client.send<Map<String, dynamic>, Map<String, dynamic>>($request);
   }
 
   @override

--- a/app/lib/src/datasource/api/deck_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_api.chopper.dart
@@ -61,9 +61,9 @@ class _$DeckApi extends DeckApi {
   }
 
   @override
-  Future<Response<dynamic>> copyDeck(String deckId) {
-    final $url = '/decks/${deckId}';
+  Future<Response<Deck>> copyDeck(String deckId) {
+    final $url = '/decks/copy/${deckId}';
     final $request = Request('POST', $url, client.baseUrl);
-    return client.send<dynamic, dynamic>($request);
+    return client.send<Deck, Deck>($request);
   }
 }

--- a/app/lib/src/datasource/api/deck_api.dart
+++ b/app/lib/src/datasource/api/deck_api.dart
@@ -1,0 +1,44 @@
+import 'package:chopper/chopper.dart';
+import 'package:memento_studio/src/entities/api/deck.dart';
+part 'deck_api.chopper.dart';
+
+typedef DeckList = List<Deck>;
+
+@ChopperApi(baseUrl: "/decks")
+abstract class DeckApi extends ChopperService {
+
+  @Get(path: "")
+  Future<Response<DeckList>> getDecks(
+    @Body() Map<String, int> pagination
+  );
+
+  @Post(
+    path: "",
+    headers: { "Content-Type": "multipart/form-data" })
+  @multipart
+  Future<Response> postDeck(
+    @Part("deck") Deck deck,
+    @PartMap() files
+  );
+
+  @Post(path: "/{id}",
+    headers: { "Content-Type": "multipart/form-data" })
+  @multipart
+  Future<Response> putDeck(
+    @Path("id") String deckId,
+    @Part() Deck deck,
+    @PartMap() files
+  );
+
+  @Delete(path: "/{id}")
+  Future<Response> deleteDeck(
+    @Path("id") String deckId
+  );
+
+  @Post(path: "/{id}")
+  Future<Response> copyDeck(
+    @Path("id") String deckId
+  );
+
+  static DeckApi create([ChopperClient? client]) => _$DeckApi(client);
+}

--- a/app/lib/src/datasource/api/deck_api.dart
+++ b/app/lib/src/datasource/api/deck_api.dart
@@ -16,12 +16,12 @@ abstract class DeckApi extends ChopperService {
     path: "",
     headers: { "Content-Type": "multipart/form-data" })
   @multipart
-  Future<Response> postDeck(
-    @Part("deck") Deck deck,
-    @PartMap() files
+  Future<Response<Deck>> postDeck(
+    @Part("deck") var deck,
+    @PartFileMap() var images
   );
 
-  @Post(path: "/{id}",
+  @Put(path: "/{id}",
     headers: { "Content-Type": "multipart/form-data" })
   @multipart
   Future<Response> putDeck(

--- a/app/lib/src/datasource/api/deck_api.dart
+++ b/app/lib/src/datasource/api/deck_api.dart
@@ -31,7 +31,7 @@ abstract class DeckApi extends ChopperService {
   );
 
   @Delete(path: "/{id}")
-  Future<Response> deleteDeck(
+  Future<Response<Map<String, dynamic>>> deleteDeck(
     @Path("id") String deckId
   );
 

--- a/app/lib/src/datasource/api/deck_api.dart
+++ b/app/lib/src/datasource/api/deck_api.dart
@@ -35,8 +35,8 @@ abstract class DeckApi extends ChopperService {
     @Path("id") String deckId
   );
 
-  @Post(path: "/{id}")
-  Future<Response> copyDeck(
+  @Post(path: "/copy/{id}")
+  Future<Response<Deck>> copyDeck(
     @Path("id") String deckId
   );
 

--- a/app/lib/src/datasource/api/deck_api.dart
+++ b/app/lib/src/datasource/api/deck_api.dart
@@ -24,10 +24,10 @@ abstract class DeckApi extends ChopperService {
   @Put(path: "/{id}",
     headers: { "Content-Type": "multipart/form-data" })
   @multipart
-  Future<Response> putDeck(
+  Future<Response<Deck>> putDeck(
     @Path("id") String deckId,
-    @Part() Deck deck,
-    @PartMap() files
+    @Part("deck") String deckUpdates,
+    @PartFileMap() var images,
   );
 
   @Delete(path: "/{id}")

--- a/app/lib/src/datasource/api/deck_reference_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_reference_api.chopper.dart
@@ -26,4 +26,11 @@ class _$DeckReferenceApi extends DeckReferenceApi {
         Request('GET', $url, client.baseUrl, body: $body, parameters: $params);
     return client.send<List<DeckReference>, DeckReference>($request);
   }
+
+  @override
+  Future<Response<Deck>> getDeck(dynamic deckId) {
+    final $url = '/decksReference/${deckId}';
+    final $request = Request('GET', $url, client.baseUrl);
+    return client.send<Deck, Deck>($request);
+  }
 }

--- a/app/lib/src/datasource/api/deck_reference_api.chopper.dart
+++ b/app/lib/src/datasource/api/deck_reference_api.chopper.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deck_reference_api.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+class _$DeckReferenceApi extends DeckReferenceApi {
+  _$DeckReferenceApi([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = DeckReferenceApi;
+
+  @override
+  Future<Response<List<DeckReference>>> getDecks(
+      int? limit, int? page, Map<String, dynamic>? filter) {
+    final $url = '/decksReference';
+    final $params = <String, dynamic>{'limit': limit, 'page': page};
+    final $body = filter;
+    final $request =
+        Request('GET', $url, client.baseUrl, body: $body, parameters: $params);
+    return client.send<List<DeckReference>, DeckReference>($request);
+  }
+}

--- a/app/lib/src/datasource/api/deck_reference_api.dart
+++ b/app/lib/src/datasource/api/deck_reference_api.dart
@@ -1,5 +1,6 @@
 import 'package:chopper/chopper.dart';
 import 'package:memento_studio/src/entities/api/deck_reference.dart';
+import 'package:memento_studio/src/entities/api/deck.dart';
 part 'deck_reference_api.chopper.dart';
 
 typedef DeckList = List<DeckReference>;
@@ -12,6 +13,11 @@ abstract class DeckReferenceApi extends ChopperService {
     @Query("limit") int? limit,
     @Query("page")  int? page,
     @Body() Map<String, dynamic>? filter
+  );
+
+  @Get(path: "/{id}")
+  Future<Response<Deck>> getDeck(
+    @Path("id") deckId
   );
 
   static DeckReferenceApi create([ChopperClient? client]) => _$DeckReferenceApi(client);

--- a/app/lib/src/datasource/api/deck_reference_api.dart
+++ b/app/lib/src/datasource/api/deck_reference_api.dart
@@ -1,0 +1,18 @@
+import 'package:chopper/chopper.dart';
+import 'package:memento_studio/src/entities/api/deck_reference.dart';
+part 'deck_reference_api.chopper.dart';
+
+typedef DeckList = List<DeckReference>;
+
+@ChopperApi(baseUrl: "/decksReference")
+abstract class DeckReferenceApi extends ChopperService {
+
+  @Get(path: "")
+  Future<Response<DeckList>> getDecks(
+    @Query("limit") int? limit,
+    @Query("page")  int? page,
+    @Body() Map<String, dynamic>? filter
+  );
+
+  static DeckReferenceApi create([ChopperClient? client]) => _$DeckReferenceApi(client);
+}

--- a/app/lib/src/datasource/api/json_converter.dart
+++ b/app/lib/src/datasource/api/json_converter.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+
+
+class JsonToTypeConverter extends JsonConverter {
+
+  final Map<Type, Function> typeToJsonFactoryMap;
+
+  JsonToTypeConverter(this.typeToJsonFactoryMap);
+
+  @override
+  Response<BodyType> convertResponse<BodyType, InnerType>(Response response) {
+    return response.copyWith(
+      body: fromJsonData<BodyType, InnerType>(response.body, typeToJsonFactoryMap[InnerType]!),
+    );
+  }
+
+  T fromJsonData<T, InnerType>(String jsonData, Function jsonParser) {
+    var jsonMap = json.decode(jsonData);
+
+    if (jsonMap is List) {
+      return jsonMap.map((item) => jsonParser(item as Map<String, dynamic>) as InnerType).toList() as T;
+    }
+
+    return jsonParser(jsonMap);
+  }
+}

--- a/app/lib/src/datasource/api/json_converter.dart
+++ b/app/lib/src/datasource/api/json_converter.dart
@@ -11,6 +11,10 @@ class JsonToTypeConverter extends JsonConverter {
 
   @override
   Response<BodyType> convertResponse<BodyType, InnerType>(Response response) {
+    if (response.bodyBytes.isEmpty) {
+      return response.copyWith(body: null);
+    }
+
     return response.copyWith(
       body: fromJsonData<BodyType, InnerType>(response.body, typeToJsonFactoryMap[InnerType]!),
     );

--- a/app/lib/src/datasource/api/user_api.chopper.dart
+++ b/app/lib/src/datasource/api/user_api.chopper.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_api.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+class _$UserApi extends UserApi {
+  _$UserApi([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = UserApi;
+
+  @override
+  Future<Response<User>> getUser() {
+    final $url = '/users';
+    final $request = Request('GET', $url, client.baseUrl);
+    return client.send<User, User>($request);
+  }
+
+  @override
+  Future<Response<User>> postUser() {
+    final $url = '/users';
+    final $request = Request('POST', $url, client.baseUrl);
+    return client.send<User, User>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteUser() {
+    final $url = '/users';
+    final $request = Request('DELETE', $url, client.baseUrl);
+    return client.send<dynamic, dynamic>($request);
+  }
+}

--- a/app/lib/src/datasource/api/user_api.dart
+++ b/app/lib/src/datasource/api/user_api.dart
@@ -1,0 +1,18 @@
+import 'package:chopper/chopper.dart';
+import 'package:memento_studio/src/entities/api/user.dart';
+part 'user_api.chopper.dart';
+
+@ChopperApi(baseUrl: "/users")
+abstract class UserApi extends ChopperService {
+
+  @Get(path: "")
+  Future<Response<User>> getUser();
+
+  @Post(path: "")
+  Future<Response<User>> postUser();
+
+  @Delete(path: "")
+  Future<Response> deleteUser();
+
+  static UserApi create([ChopperClient? client]) => _$UserApi(client);
+}

--- a/app/lib/src/entities/api/card.dart
+++ b/app/lib/src/entities/api/card.dart
@@ -1,0 +1,39 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../local/card.dart' as local;
+
+part 'card.g.dart';
+
+@JsonSerializable()
+class Card {
+  
+  @JsonKey(name: 'uuid')
+  String? id;
+
+  @JsonKey(name: 'frontText')  
+  String? frontText;
+
+  @JsonKey(name: 'frontImagePath')
+  String? frontImage;
+
+  @JsonKey(name: 'backText')
+  String? backText;
+
+  @JsonKey(name: 'backImagePath')
+  String? backImage;
+
+  Card({this.id, this.frontText, this.frontImage, this.backText, this.backImage});
+
+  factory Card.fromJson(Map<String, dynamic> json) => _$CardFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CardToJson(this);
+
+  local.Card toDomainModel() {
+    return local.Card(
+      id: id ?? "",
+      frontImage: frontImage,
+      frontText: frontText,
+      backImage: backImage,
+      backText: backText
+    );
+  }
+}

--- a/app/lib/src/entities/api/card.g.dart
+++ b/app/lib/src/entities/api/card.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'card.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Card _$CardFromJson(Map<String, dynamic> json) => Card(
+      id: json['uuid'] as String?,
+      frontText: json['frontText'] as String?,
+      frontImage: json['frontImagePath'] as String?,
+      backText: json['backText'] as String?,
+      backImage: json['backImagePath'] as String?,
+    );
+
+Map<String, dynamic> _$CardToJson(Card instance) => <String, dynamic>{
+      'uuid': instance.id,
+      'frontText': instance.frontText,
+      'frontImagePath': instance.frontImage,
+      'backText': instance.backText,
+      'backImagePath': instance.backImage,
+    };

--- a/app/lib/src/entities/api/deck.dart
+++ b/app/lib/src/entities/api/deck.dart
@@ -1,0 +1,53 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../local/deck.dart' as local_deck;
+import '../local/card.dart' as local_card;
+import 'card.dart';
+
+part 'deck.g.dart';
+
+@JsonSerializable()
+class Deck {
+
+  @JsonKey(name: 'UUID')
+  final String? id;
+
+  @JsonKey(name: 'cards')
+  final List<Card>? cards;
+
+  @JsonKey(name: 'description')
+  final String? description;
+
+  @JsonKey(name: 'cover')
+  final String? cover;
+
+  @JsonKey(name: 'name')
+  final String? name;
+
+  @JsonKey(name: 'isPublic')
+  final bool? isPublic;
+
+  @JsonKey(name: 'tags')
+  final List<String>? tags;
+
+  @JsonKey(name: 'lastModification')
+  final int? lastModification;
+
+  Deck({this.id, this.cards, this.description, this.cover, this.name, this.isPublic, this.tags, this.lastModification});
+
+  factory Deck.fromJson(Map<String, dynamic> json) => _$DeckFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeckToJson(this);
+
+  local_deck.Deck toDomainModel() {
+    return local_deck.Deck(
+        id: id!, 
+        description: description ?? "", 
+        cover: cover,
+        name: name ?? "",
+        isPublic: isPublic ?? false,
+        tags: tags ?? [],
+        lastModification: DateTime.fromMicrosecondsSinceEpoch(lastModification ?? 0), // TODO: mudar pro formato correto
+        cards: cards?.map((card) => card.toDomainModel()).toList() ?? <local_card.Card>[]
+      );
+  }
+}

--- a/app/lib/src/entities/api/deck.g.dart
+++ b/app/lib/src/entities/api/deck.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deck.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Deck _$DeckFromJson(Map<String, dynamic> json) => Deck(
+      id: json['UUID'] as String?,
+      cards: (json['cards'] as List<dynamic>?)
+          ?.map((e) => Card.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      description: json['description'] as String?,
+      cover: json['cover'] as String?,
+      name: json['name'] as String?,
+      isPublic: json['isPublic'] as bool?,
+      tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      lastModification: json['lastModification'] as int?,
+    );
+
+Map<String, dynamic> _$DeckToJson(Deck instance) => <String, dynamic>{
+      'UUID': instance.id,
+      'cards': instance.cards,
+      'description': instance.description,
+      'cover': instance.cover,
+      'name': instance.name,
+      'isPublic': instance.isPublic,
+      'tags': instance.tags,
+      'lastModification': instance.lastModification,
+    };

--- a/app/lib/src/entities/api/deck_reference.dart
+++ b/app/lib/src/entities/api/deck_reference.dart
@@ -1,0 +1,54 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:memento_studio/src/entities/local/deck_reference.dart' as local_model;
+
+part 'deck_reference.g.dart';
+
+@JsonSerializable()
+class DeckReference {
+  @JsonKey(name: 'UUID')
+  final String id;
+
+  @JsonKey(name: 'Description')
+  final String description;
+
+  @JsonKey(name: 'Cover')
+  final String? cover;
+
+  @JsonKey(name: 'Name')
+  final String name;
+
+  @JsonKey(name: 'Tags')
+  final List<String> tags;
+
+  @JsonKey(name: 'Author')
+  final String? author;
+
+  @JsonKey(name: 'NumberOfCards')
+  final int numberOfCards;
+
+  DeckReference({
+    required this.id,
+    this.description = "",
+    this.cover = "",
+    this.name = "",
+    this.tags = const [],
+    this.author = "",
+    this.numberOfCards = 0,
+  });
+
+  factory DeckReference.fromJson(Map<String, dynamic> json) => _$DeckReferenceFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeckReferenceToJson(this);
+
+  local_model.DeckReference toDomainModel() {
+    return local_model.DeckReference(
+        id: id, 
+        description: description, 
+        cover: cover,
+        name: name,
+        tags: tags,
+        numberOfCards: numberOfCards,
+        author: author
+      );
+  }
+}

--- a/app/lib/src/entities/api/deck_reference.g.dart
+++ b/app/lib/src/entities/api/deck_reference.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deck_reference.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DeckReference _$DeckReferenceFromJson(Map<String, dynamic> json) =>
+    DeckReference(
+      id: json['UUID'] as String,
+      description: json['Description'] as String? ?? "",
+      cover: json['Cover'] as String? ?? "",
+      name: json['Name'] as String? ?? "",
+      tags:
+          (json['Tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+              const [],
+      author: json['Author'] as String? ?? "",
+      numberOfCards: json['NumberOfCards'] as int? ?? 0,
+    );
+
+Map<String, dynamic> _$DeckReferenceToJson(DeckReference instance) =>
+    <String, dynamic>{
+      'UUID': instance.id,
+      'Description': instance.description,
+      'Cover': instance.cover,
+      'Name': instance.name,
+      'Tags': instance.tags,
+      'Author': instance.author,
+      'NumberOfCards': instance.numberOfCards,
+    };

--- a/app/lib/src/entities/api/user.dart
+++ b/app/lib/src/entities/api/user.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'user.g.dart';
+
+@JsonSerializable()
+class User {
+
+  @JsonKey(name: 'UUID')
+  final String? id;
+
+  @JsonKey(name: 'decks')
+  final List<String>? decks;
+
+  @JsonKey(name: 'lastSynchronization')
+  final int? lastSynchronization;
+
+  User({this.id, this.decks, this.lastSynchronization});
+
+  factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserToJson(this);
+}

--- a/app/lib/src/entities/api/user.g.dart
+++ b/app/lib/src/entities/api/user.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+User _$UserFromJson(Map<String, dynamic> json) => User(
+      id: json['UUID'] as String?,
+      decks:
+          (json['decks'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      lastSynchronization: json['lastSynchronization'] as int?,
+    );
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'UUID': instance.id,
+      'decks': instance.decks,
+      'lastSynchronization': instance.lastSynchronization,
+    };

--- a/app/lib/src/entities/local/deck_reference.dart
+++ b/app/lib/src/entities/local/deck_reference.dart
@@ -1,0 +1,25 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:memento_studio/src/entities.dart';
+
+part 'deck_reference.g.dart';
+
+@CopyWith()
+class DeckReference {
+  final String id;
+  final String? description;
+  final String? cover;
+  final String name;
+  final List<String> tags;
+  final String? author;
+  final int numberOfCards;
+
+  DeckReference({
+    required this.id,
+    this.description,
+    this.cover,
+    required this.name,
+    this.tags = const [],
+    this.author,
+    this.numberOfCards = 0,
+  });
+}

--- a/app/lib/src/entities/local/deck_reference.g.dart
+++ b/app/lib/src/entities/local/deck_reference.g.dart
@@ -1,0 +1,124 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deck_reference.dart';
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$DeckReferenceCWProxy {
+  DeckReference author(String? author);
+
+  DeckReference cover(String? cover);
+
+  DeckReference description(String? description);
+
+  DeckReference id(String id);
+
+  DeckReference name(String name);
+
+  DeckReference numberOfCards(int numberOfCards);
+
+  DeckReference tags(List<String> tags);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `DeckReference(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// DeckReference(...).copyWith(id: 12, name: "My name")
+  /// ````
+  DeckReference call({
+    String? author,
+    String? cover,
+    String? description,
+    String? id,
+    String? name,
+    int? numberOfCards,
+    List<String>? tags,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfDeckReference.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfDeckReference.copyWith.fieldName(...)`
+class _$DeckReferenceCWProxyImpl implements _$DeckReferenceCWProxy {
+  final DeckReference _value;
+
+  const _$DeckReferenceCWProxyImpl(this._value);
+
+  @override
+  DeckReference author(String? author) => this(author: author);
+
+  @override
+  DeckReference cover(String? cover) => this(cover: cover);
+
+  @override
+  DeckReference description(String? description) =>
+      this(description: description);
+
+  @override
+  DeckReference id(String id) => this(id: id);
+
+  @override
+  DeckReference name(String name) => this(name: name);
+
+  @override
+  DeckReference numberOfCards(int numberOfCards) =>
+      this(numberOfCards: numberOfCards);
+
+  @override
+  DeckReference tags(List<String> tags) => this(tags: tags);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `DeckReference(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// DeckReference(...).copyWith(id: 12, name: "My name")
+  /// ````
+  DeckReference call({
+    Object? author = const $CopyWithPlaceholder(),
+    Object? cover = const $CopyWithPlaceholder(),
+    Object? description = const $CopyWithPlaceholder(),
+    Object? id = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? numberOfCards = const $CopyWithPlaceholder(),
+    Object? tags = const $CopyWithPlaceholder(),
+  }) {
+    return DeckReference(
+      author: author == const $CopyWithPlaceholder()
+          ? _value.author
+          // ignore: cast_nullable_to_non_nullable
+          : author as String?,
+      cover: cover == const $CopyWithPlaceholder()
+          ? _value.cover
+          // ignore: cast_nullable_to_non_nullable
+          : cover as String?,
+      description: description == const $CopyWithPlaceholder()
+          ? _value.description
+          // ignore: cast_nullable_to_non_nullable
+          : description as String?,
+      id: id == const $CopyWithPlaceholder() || id == null
+          ? _value.id
+          // ignore: cast_nullable_to_non_nullable
+          : id as String,
+      name: name == const $CopyWithPlaceholder() || name == null
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as String,
+      numberOfCards:
+          numberOfCards == const $CopyWithPlaceholder() || numberOfCards == null
+              ? _value.numberOfCards
+              // ignore: cast_nullable_to_non_nullable
+              : numberOfCards as int,
+      tags: tags == const $CopyWithPlaceholder() || tags == null
+          ? _value.tags
+          // ignore: cast_nullable_to_non_nullable
+          : tags as List<String>,
+    );
+  }
+}
+
+extension $DeckReferenceCopyWith on DeckReference {
+  /// Returns a callable class that can be used as follows: `instanceOfDeckReference.copyWith(...)` or like so:`instanceOfDeckReference.copyWith.fieldName(...)`.
+  _$DeckReferenceCWProxy get copyWith => _$DeckReferenceCWProxyImpl(this);
+}

--- a/app/lib/src/entities/local/result.dart
+++ b/app/lib/src/entities/local/result.dart
@@ -1,0 +1,14 @@
+abstract class Result<T> {
+}
+
+class Success<T> extends Result<T> {
+  final T value;
+
+  Success(this.value);
+}
+
+class Error<T> extends Result<T> {
+  final Exception exception;
+
+  Error(this.exception);
+}

--- a/app/lib/src/repositories/deck_reference_repository.dart
+++ b/app/lib/src/repositories/deck_reference_repository.dart
@@ -1,0 +1,30 @@
+import '../datasource/api/deck_reference_api.dart';
+import '../entities/local/result.dart';
+import 'interfaces/deck_reference_repository_interface.dart';
+import 'package:memento_studio/src/entities/local/result.dart';
+import 'package:memento_studio/src/entities/local/deck_reference.dart' as local_model;
+
+typedef DeckListResult = Result<List<local_model.DeckReference>>;
+
+class DeckReferenceRepository extends DeckReferenceRepositoryInterface {
+  DeckReferenceApi api;
+
+  DeckReferenceRepository(this.api);
+
+  Future<DeckListResult> getDecks(int page, int pageSize, Map<String, dynamic>? filter) async {
+    final response = await api.getDecks(page, pageSize, filter);
+
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deckApiList = response.body;
+      List<local_model.DeckReference> decks = deckApiList?.map((deck) => deck.toDomainModel()).toList() ?? <local_model.DeckReference>[];
+      
+      return Success(decks);
+    }
+  }
+
+  // Future<DeckResult> getDeck(String id) async {
+
+  // }
+}

--- a/app/lib/src/repositories/deck_reference_repository.dart
+++ b/app/lib/src/repositories/deck_reference_repository.dart
@@ -3,14 +3,17 @@ import '../entities/local/result.dart';
 import 'interfaces/deck_reference_repository_interface.dart';
 import 'package:memento_studio/src/entities/local/result.dart';
 import 'package:memento_studio/src/entities/local/deck_reference.dart' as local_model;
+import 'package:memento_studio/src/entities/local/deck.dart';
 
 typedef DeckListResult = Result<List<local_model.DeckReference>>;
+typedef DeckResult = Result<Deck>;
 
 class DeckReferenceRepository extends DeckReferenceRepositoryInterface {
   DeckReferenceApi api;
 
   DeckReferenceRepository(this.api);
 
+  @override
   Future<DeckListResult> getDecks(int page, int pageSize, Map<String, dynamic>? filter) async {
     final response = await api.getDecks(page, pageSize, filter);
 
@@ -24,7 +27,20 @@ class DeckReferenceRepository extends DeckReferenceRepositoryInterface {
     }
   }
 
-  // Future<DeckResult> getDeck(String id) async {
+  @override
+  Future<DeckResult> getDeck(String id) async {
+    final response = await api.getDeck(id);
 
-  // }
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deck = response.body?.toDomainModel();
+
+      if (deck == null) {
+        return Error(Exception("Could not parse response body to deck model"));
+      }
+      
+      return Success(deck);
+    }
+  }
 }

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -33,6 +33,7 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
+  @override
   Future<DeckResult> saveDeck(local_model.Deck newDeck, Map<String, Uint8List> images) async {
     // Adiciona as imagens em uma part para ser enviada na requisicao
     List<PartValueFile> parts = [];
@@ -78,6 +79,7 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
+  @override
   Future<DeckResult> updateDeck(String id, Map<String, dynamic> deckUpdates, Map<String, Uint8List> images) async {
     // Adiciona as imagens em uma part para ser enviada na requisicao
     List<PartValueFile> parts = [];
@@ -102,6 +104,7 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
+  @override
   Future<Result> deleteDeck(String id) async {
     final response = await _api.deleteDeck(id);
 
@@ -113,6 +116,7 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
+  @override
   Future<DeckResult> copyDeck(String id) async {
     final response = await _api.copyDeck(id);
 

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -113,8 +113,20 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
-  // Future<Response> copyDeck() {
-  //   Future<Response> response = _api.copyDeck();
-  //   return response;
-  // }
+  Future<DeckResult> copyDeck(String id) async {
+    final response = await _api.copyDeck(id);
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deck = response.body?.toDomainModel();
+
+      if (deck == null) {
+        return Error(Exception("Could not parse response body to deck model"));
+      }
+      
+      return Success(deck);
+    }
+  }
 }

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -1,0 +1,49 @@
+import 'package:memento_studio/src/datasource/api/deck_api.dart';
+import 'package:memento_studio/src/repositories/interfaces/deck_repository_interface.dart';
+import 'package:memento_studio/src/entities/local/result.dart';
+import 'package:memento_studio/src/entities/local/deck.dart' as local_model;
+
+typedef DeckListResult = Result<List<local_model.Deck>>;
+typedef DeckResult = Result<local_model.Deck>;
+
+class DeckRepository extends DeckRepositoryInterface{
+  final DeckApi _api;
+
+  DeckRepository(this._api);
+
+  @override
+  Future<DeckListResult> getDecks(int page, int pageSize) async{
+    Map<String, int> pagination = {'page': page, 'limit': pageSize};
+
+    final response = await _api.getDecks(pagination);
+
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deckApiList = response.body;
+      List<local_model.Deck> decks = deckApiList?.map((deck) => deck.toDomainModel()).toList() ?? <local_model.Deck>[];
+      
+      return Success(decks);
+    }
+  }
+
+  // Future<Response> saveDeck() {
+  //   Future<Response> response = _api.postDeck();
+  //   return response;
+  // }
+
+  // Future<Response> updateDeck() {
+  //   Future<Response> response = _api.putDeck();
+  //   return response;
+  // }
+
+  // Future<Response> deleteDeck() {
+  //   Future<Response> response = _api.deleteDeck();
+  //   return response;
+  // }
+
+  // Future<Response> copyDeck() {
+  //   Future<Response> response = _api.copyDeck();
+  //   return response;
+  // }
+}

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -78,10 +78,29 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
-  // Future<Response> updateDeck() {
-  //   Future<Response> response = _api.putDeck();
-  //   return response;
-  // }
+  Future<DeckResult> updateDeck(String id, Map<String, dynamic> deckUpdates, Map<String, Uint8List> images) async {
+    // Adiciona as imagens em uma part para ser enviada na requisicao
+    List<PartValueFile> parts = [];
+    images.forEach((key, value) { 
+      parts.add(PartValueFile(key, value));
+    });
+
+    // Envia requisição PUT
+    final response = await _api.putDeck(id, json.encode(deckUpdates), parts);
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deck = response.body?.toDomainModel();
+
+      if (deck == null) {
+        return Error(Exception("Could not parse response body to deck model"));
+      }
+      
+      return Success(deck);
+    }
+  }
 
   // Future<Response> deleteDeck() {
   //   Future<Response> response = _api.deleteDeck();

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -102,10 +102,16 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
-  // Future<Response> deleteDeck() {
-  //   Future<Response> response = _api.deleteDeck();
-  //   return response;
-  // }
+  Future<Result> deleteDeck(String id) async {
+    final response = await _api.deleteDeck(id);
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {    
+      return Success(response.body);
+    }
+  }
 
   // Future<Response> copyDeck() {
   //   Future<Response> response = _api.copyDeck();

--- a/app/lib/src/repositories/deck_repository.dart
+++ b/app/lib/src/repositories/deck_repository.dart
@@ -1,7 +1,13 @@
+import 'dart:typed_data';
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
 import 'package:memento_studio/src/datasource/api/deck_api.dart';
 import 'package:memento_studio/src/repositories/interfaces/deck_repository_interface.dart';
 import 'package:memento_studio/src/entities/local/result.dart';
 import 'package:memento_studio/src/entities/local/deck.dart' as local_model;
+import 'package:memento_studio/src/entities/api/deck.dart' as api_model;
+import 'package:memento_studio/src/entities/api/card.dart' as api_model_card;
 
 typedef DeckListResult = Result<List<local_model.Deck>>;
 typedef DeckResult = Result<local_model.Deck>;
@@ -12,7 +18,7 @@ class DeckRepository extends DeckRepositoryInterface{
   DeckRepository(this._api);
 
   @override
-  Future<DeckListResult> getDecks(int page, int pageSize) async{
+  Future<DeckListResult> getDecks(int page, int pageSize) async {
     Map<String, int> pagination = {'page': page, 'limit': pageSize};
 
     final response = await _api.getDecks(pagination);
@@ -27,10 +33,50 @@ class DeckRepository extends DeckRepositoryInterface{
     }
   }
 
-  // Future<Response> saveDeck() {
-  //   Future<Response> response = _api.postDeck();
-  //   return response;
-  // }
+  Future<DeckResult> saveDeck(local_model.Deck newDeck, Map<String, Uint8List> images) async {
+    // Adiciona as imagens em uma part para ser enviada na requisicao
+    List<PartValueFile> parts = [];
+    images.forEach((key, value) { 
+      parts.add(PartValueFile(key, value));
+    });
+
+    // Converte o baralho pro modelo da api
+    final cardsApi = <api_model_card.Card>[];
+    newDeck.cards.forEach((c) {
+      cardsApi.add(
+        api_model_card.Card(
+          backText: c.backText,
+          frontText: c.frontText,
+          id: c.id)
+        );
+    });
+
+    final newDeckApi = api_model.Deck(
+        cards: cardsApi,
+        id: newDeck.id,
+        description: newDeck.description,
+        name: newDeck.name,
+        isPublic: newDeck.isPublic,
+        tags: newDeck.tags,
+        lastModification: newDeck.lastModification.microsecondsSinceEpoch
+      );
+
+    // Envia requisição POST
+    final response = await _api.postDeck(json.encode(newDeckApi.toJson()), parts);
+    
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      final deck = response.body?.toDomainModel();
+
+      if (deck == null) {
+        return Error(Exception("Could not parse response body to deck model"));
+      }
+      
+      return Success(deck);
+    }
+  }
 
   // Future<Response> updateDeck() {
   //   Future<Response> response = _api.putDeck();

--- a/app/lib/src/repositories/interfaces/deck_reference_repository_interface.dart
+++ b/app/lib/src/repositories/interfaces/deck_reference_repository_interface.dart
@@ -1,3 +1,4 @@
 abstract class DeckReferenceRepositoryInterface {
   dynamic getDecks(int page, int pageSize, Map<String, dynamic>? filter);
+  dynamic getDeck(String id);
 }

--- a/app/lib/src/repositories/interfaces/deck_reference_repository_interface.dart
+++ b/app/lib/src/repositories/interfaces/deck_reference_repository_interface.dart
@@ -1,0 +1,3 @@
+abstract class DeckReferenceRepositoryInterface {
+  dynamic getDecks(int page, int pageSize, Map<String, dynamic>? filter);
+}

--- a/app/lib/src/repositories/interfaces/deck_repository_interface.dart
+++ b/app/lib/src/repositories/interfaces/deck_repository_interface.dart
@@ -1,11 +1,15 @@
+import 'dart:typed_data';
+
+import '../../entities/local/deck.dart';
+
 abstract class DeckRepositoryInterface {
   dynamic getDecks(int page, int pageSize);
 
-  // dynamic saveDeck();
+  dynamic saveDeck(Deck newDeck, Map<String, Uint8List> images);
 
-  // dynamic updateDeck();
+  dynamic updateDeck(String id, Map<String, dynamic> deckUpdates, Map<String, Uint8List> images);
 
-  // dynamic deleteDeck();
+  dynamic deleteDeck(String id);
 
-  // dynamic copyDeck();
+  dynamic copyDeck(String id);
 }

--- a/app/lib/src/repositories/interfaces/deck_repository_interface.dart
+++ b/app/lib/src/repositories/interfaces/deck_repository_interface.dart
@@ -1,0 +1,11 @@
+abstract class DeckRepositoryInterface {
+  dynamic getDecks(int page, int pageSize);
+
+  // dynamic saveDeck();
+
+  // dynamic updateDeck();
+
+  // dynamic deleteDeck();
+
+  // dynamic copyDeck();
+}

--- a/app/lib/src/repositories/interfaces/user_repository_interface.dart
+++ b/app/lib/src/repositories/interfaces/user_repository_interface.dart
@@ -1,0 +1,7 @@
+abstract class UserRepositoryInterface {
+  dynamic getUser();
+
+  dynamic createUser();
+  
+  dynamic deleteUser();
+}

--- a/app/lib/src/repositories/user_repository.dart
+++ b/app/lib/src/repositories/user_repository.dart
@@ -1,5 +1,3 @@
-import 'package:chopper/chopper.dart';
-
 import '../datasource/api/user_api.dart';
 import '../entities/api/user.dart';
 import '../entities/local/result.dart';

--- a/app/lib/src/repositories/user_repository.dart
+++ b/app/lib/src/repositories/user_repository.dart
@@ -1,0 +1,54 @@
+import 'package:chopper/chopper.dart';
+
+import '../datasource/api/user_api.dart';
+import '../entities/api/user.dart';
+import '../entities/local/result.dart';
+import 'interfaces/user_repository_interface.dart';
+
+class UserRepository extends UserRepositoryInterface {
+  UserApi api;
+
+  UserRepository(this.api);
+
+  Future<Result<User>> getUser() async {
+    final response = await api.getUser();
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      if (response.body == null) {
+        return Error(Exception("Could not parse response body"));
+      }
+      
+      return Success(response.body!);
+    }
+  }
+
+  Future<Result<User>> createUser() async {
+    final response = await api.postUser();
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.error.toString()));
+    } else {
+      if (response.body == null) {
+        return Error(Exception("Could not parse response body"));
+      }
+      
+      return Success(response.body!);
+    }
+  }
+
+  Future<Result> deleteUser() async {
+    final response = await api.deleteUser();
+
+    // Trata resposta
+    if (!response.isSuccessful) {
+      return Error(Exception(response.body));
+    } else {
+      return Success(response.body);
+    }
+  }
+}
+

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -120,6 +120,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  chopper:
+    dependency: "direct main"
+    description:
+      name: chopper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
+  chopper_generator:
+    dependency: "direct dev"
+    description:
+      name: chopper_generator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
   clock:
     dependency: transitive
     description:
@@ -394,6 +408,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
@@ -444,12 +465,19 @@ packages:
     source: hosted
     version: "0.6.4"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.5.0"
+  json_serializable:
+    dependency: "direct main"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.2.0"
   kiwi:
     dependency: "direct main"
     description:
@@ -472,7 +500,7 @@ packages:
     source: hosted
     version: "1.1.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       url: "https://pub.dartlang.org"
@@ -651,6 +679,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.2"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,6 +51,10 @@ dependencies:
   flutter_svg: ^1.1.1+1
   font_awesome_flutter: ^10.1.0
   logger: ^1.1.0
+  chopper: ^4.0.6
+  json_annotation: ^4.0.0
+  json_serializable: ^6.1.5
+  logging: ^1.0.0
 
 dev_dependencies:
   flutter_test:
@@ -64,6 +68,8 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   copy_with_extension_gen: ^4.0.2
   mocktail: ^0.3.0
+  chopper_generator: ^4.0.6
+  test: ^1.21.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:1.18
 WORKDIR /app
 COPY . .
 
+VOLUME /public
+
 RUN go get -d -v ./src/
 RUN go build -o server -v ./src/
 

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -9,7 +9,10 @@ services:
       - MONGO_PORT=27017
       - MONGO_USERNAME=root
       - MONGO_PASSWORD=PI-UFES-2022
+      - IMAGES_FILE_PATH=public/
     network_mode: "host"
+    volumes:
+      - ./public:/app/public:consistent
 
   mongo:
     image: mongo:latest

--- a/server/src/controllers/deck_controller.go
+++ b/server/src/controllers/deck_controller.go
@@ -331,6 +331,7 @@ func PutDeck(context *gin.Context) {
 	deckInDB, errRepo := deckRepository.Read(id)
 	if errRepo != nil {
 		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
+		return
 	}
 
 	// Check if user owns this deck

--- a/server/src/controllers/deck_controller.go
+++ b/server/src/controllers/deck_controller.go
@@ -56,14 +56,14 @@ func DeleteDeck(context *gin.Context) {
 	user.Decks = utils.Remove(user.Decks, id)
 	errRepo := userRepository.UpdateDecks(user.UUID, user.Decks)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
 	// Delete deck
 	err := deckRepository.Delete(id)
 	if err != nil {
-		context.JSON(handleRepositoryError(err), err.Error())
+		context.JSON(utils.HandleRepositoryError(err), err.Error())
 		return
 	}
 
@@ -178,14 +178,14 @@ func PostDecks(context *gin.Context) {
 	deck.Cards = cardsUpdated
 	_, _, errRepo := deckRepository.InsertOrUpdate(&deck)
 	if err != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
 	// Insert or update deckReference
 	errRepo = updateIsPublicStatus(deck, deckReferenceRepository)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
@@ -197,7 +197,7 @@ func PostDecks(context *gin.Context) {
 
 	errRepo = userRepository.UpdateDecks(user.UUID, deckIds)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
@@ -241,7 +241,7 @@ func GetDecks(context *gin.Context) {
 
 	decksResult, errRepo := deckRepository.ReadAll(user.Decks, (int)(limit), (int)(page))
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 	
@@ -263,7 +263,7 @@ func CopyDeck(context *gin.Context) {
 	// Get deck from db
 	deck, errRepo := deckRepository.Read(id)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
@@ -296,13 +296,13 @@ func CopyDeck(context *gin.Context) {
 	// Save deck and user updated
 	_, _, errRepo = deckRepository.InsertOrUpdate(&deckCopy)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
 	errRepo = userRepository.UpdateDecks(user.UUID, user.Decks)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
@@ -330,7 +330,7 @@ func PutDeck(context *gin.Context) {
 	// Check if deck exists
 	deckInDB, errRepo := deckRepository.Read(id)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 	}
 
 	// Check if user owns this deck
@@ -434,14 +434,14 @@ func PutDeck(context *gin.Context) {
 	// Insert or update deckReference
 	errRepo = updateIsPublicStatus(*deckInDB, deckReferenceRepository)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
 	// Save updated deck in DB
 	_, _, errRepo = deckRepository.InsertOrUpdate(deckInDB)
 	if errRepo != nil {
-		context.JSON(handleRepositoryError(errRepo), errRepo.Error())
+		context.JSON(utils.HandleRepositoryError(errRepo), errRepo.Error())
 		return
 	}
 
@@ -457,22 +457,11 @@ func getUser(context *gin.Context, userRepository UserRepository) *models.User {
 
 	user, err := userRepository.Read(userid)
 	if err != nil {
-		context.JSON(handleRepositoryError(err), err.Error())
+		context.JSON(utils.HandleRepositoryError(err), err.Error())
 		return nil
 	}
 
 	return user
-}
-
-func handleRepositoryError(err *errors.RepositoryError) int {
-	switch err.Code {
-	case errors.DuplicateKey:
-		return http.StatusForbidden
-	case errors.Timeout:
-		return http.StatusRequestTimeout
-	default:
-		return http.StatusInternalServerError
-	}
 }
 
 func getDeckWithImages(reader *multipart.Reader) ([]byte, fileBytes, map[string]fileBytes, map[string]fileBytes, error) {

--- a/server/src/controllers/deck_controller.go
+++ b/server/src/controllers/deck_controller.go
@@ -212,25 +212,24 @@ func GetDecks(context *gin.Context) {
 
 	// Get requisition's body
 	var reqBody map[string]interface{}
-	err := utils.GetRequestBody(context.Request.Body, &reqBody)
-	if err != nil {
-		context.JSON(http.StatusBadRequest, err.Error())
-		return
+
+	if context.Request.Body != nil {
+		err := utils.GetRequestBody(context.Request.Body, &reqBody)
+		if err != nil {
+			context.JSON(http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	// Get decks from db
-	if reqBody["limit"] == nil {
-		reqBody["limit"] = 30
-	}
-	if reqBody["page"] == nil {
-		reqBody["page"] = 1
-	}
-
 	limit, okLim := reqBody["limit"].(float64)
 	page, okPage := reqBody["page"].(float64)
-	if !okLim || !okPage {
-		context.JSON(http.StatusBadRequest, "Limite e página devem ser um número")
-		return
+	if !okLim {
+		limit = 30
+	}
+	
+	if !okPage {
+		page = 1
 	}
 
 	decksResult, errRepo := deckRepository.ReadAll(user.Decks, (int)(limit), (int)(page))

--- a/server/src/controllers/deck_reference_controller.go
+++ b/server/src/controllers/deck_reference_controller.go
@@ -43,12 +43,10 @@ func ReadAllDeckReference(ginContext *gin.Context) {
 	}
 
 	var filter map[string]interface{}
-	if ginContext.Request.Body != nil {
-		err := utils.GetRequestBody(ginContext.Request.Body, &filter)
-		if err != nil {
-			ginContext.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
-			return
-		}
+	err := utils.GetRequestBody(ginContext.Request.Body, &filter)
+	if err != nil {
+		ginContext.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
 	}
 
 	decksReference, decksReferenceErr := deckReferenceRepo.ReadAll(limit, page, filter)

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	database := client.Database(databaseName)
 
-	server.StaticFS("/image", http.Dir("public"))
+	server.StaticFS("/image", gin.Dir("public", false))
 
 	// Estruturas que serão utilizadas por todas as rotas
 	server.Use(func(context *gin.Context) {

--- a/server/src/models/deck.go
+++ b/server/src/models/deck.go
@@ -8,5 +8,5 @@ type Deck struct {
 	LastModification int64    `json:"lastModification" bson:"lastModification,omitempty"`
 	Name             string   `json:"name" bson:"name,omitempty"`
 	Tags             []string `json:"tags" bson:"tags, omitempty"`
-	UUID             string   `bson:"_id"`
+	UUID             string   `json:"UUID" bson:"_id"`
 }

--- a/server/src/routes/deck_references.go
+++ b/server/src/routes/deck_references.go
@@ -7,6 +7,8 @@ import (
 )
 
 func DeckReferenceRoutes(routerGroup *gin.RouterGroup) {
-	userGroup := routerGroup.Group("/decksReference")
-	userGroup.GET("", controllers.ReadAllDeckReference)
+	deckReferenceGroup := routerGroup.Group("/decksReference")
+
+	deckReferenceGroup.GET("", controllers.ReadAllDeckReference)
+	deckReferenceGroup.GET("/:id", controllers.GetPublicDeck)
 }

--- a/server/src/utils/file_utils.go
+++ b/server/src/utils/file_utils.go
@@ -11,11 +11,13 @@ const (
 	imagesDirKey	= "IMAGES_FILE_PATH"
 )
 
-func UploadFile(file []byte, filename string) (string, error) {
-	var imageFilepath = ImagesRoute + "/" + filename
-	var imagesDir = getImagesFilePath()
+func UploadFile(file []byte, folderName, filename string) (string, error) {
+	var imageFilepath = ImagesRoute + "/" + folderName + "/" + filename
+	var imagesDir = GetImagesFilePath()
 
-	err := os.WriteFile(imagesDir + filename, file, 0644)
+	os.Mkdir(imagesDir + "/" + folderName, 0755)
+
+	err := os.WriteFile(imagesDir + folderName + "/" + filename, file, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -23,9 +25,13 @@ func UploadFile(file []byte, filename string) (string, error) {
 	return imageFilepath, nil
 }
 
-func RemoveFile(onlinePath string) error {
+func RemoveFile(onlinePath, folder string) error {
 	filename := strings.Replace(onlinePath, ImagesRoute + "/", "", -1)
-	var imagesDir = getImagesFilePath()
+	if !strings.Contains(filename, folder) {
+		return nil
+	}
+
+	var imagesDir = GetImagesFilePath()
 
 	absPath, _ := filepath.Abs(imagesDir + filename)
 
@@ -34,7 +40,17 @@ func RemoveFile(onlinePath string) error {
 	return err
 }
 
-func getImagesFilePath() string {
+func RemoveFolder(folder string) error {
+	var imagesDir = GetImagesFilePath()
+
+	absPath, _ := filepath.Abs(imagesDir + folder)
+
+	err := os.RemoveAll(absPath)
+
+	return err
+}
+
+func GetImagesFilePath() string {
 	var imagesDir	  = "../../public/" // for tests
 
 	if value, ok := os.LookupEnv(imagesDirKey); ok { // in container

--- a/server/src/utils/file_utils.go
+++ b/server/src/utils/file_utils.go
@@ -8,14 +8,14 @@ import (
 
 const (
 	ImagesRoute 	= "http://localhost:8080/image"
-	ImagesDir 		= "../../public/"
+	imagesDirKey	= "IMAGES_FILE_PATH"
 )
 
 func UploadFile(file []byte, filename string) (string, error) {
 	var imageFilepath = ImagesRoute + "/" + filename
-	absPath, _ := filepath.Abs(ImagesDir + filename)
+	var imagesDir = getImagesFilePath()
 
-	err := os.WriteFile(absPath, file, 0644)
+	err := os.WriteFile(imagesDir + filename, file, 0644)
 	if err != nil {
 		return "", err
 	}
@@ -25,9 +25,21 @@ func UploadFile(file []byte, filename string) (string, error) {
 
 func RemoveFile(onlinePath string) error {
 	filename := strings.Replace(onlinePath, ImagesRoute + "/", "", -1)
-	absPath, _ := filepath.Abs(ImagesDir + filename)
+	var imagesDir = getImagesFilePath()
+
+	absPath, _ := filepath.Abs(imagesDir + filename)
 
 	err := os.Remove(absPath)
 
 	return err
+}
+
+func getImagesFilePath() string {
+	var imagesDir	  = "../../public/" // for tests
+
+	if value, ok := os.LookupEnv(imagesDirKey); ok { // in container
+		imagesDir = value
+	}
+
+	return imagesDir
 }

--- a/server/src/utils/utils.go
+++ b/server/src/utils/utils.go
@@ -37,6 +37,11 @@ func GetRequestBody(bodyBuffer io.ReadCloser, result *map[string]interface{}) er
 	bodyBytes, _ := ioutil.ReadAll(bodyBuffer)
 	defer bodyBuffer.Close()
 
+	if len(bodyBytes) == 0 {
+		result = nil
+		return nil
+	}
+
 	err := json.Unmarshal(bodyBytes, result)
 
 	return err

--- a/server/src/utils/utils.go
+++ b/server/src/utils/utils.go
@@ -3,8 +3,11 @@ package utils
 import (
 	"os"
 	"io"
+	"net/http"
 	"io/ioutil"
 	"encoding/json"
+
+	"server/src/errors"
 )
 type compareFunc func(interface{}, interface{}) bool
 
@@ -47,4 +50,15 @@ func Remove(arr []string, value string) []string {
 	}
 
 	return arr
+}
+
+func HandleRepositoryError(err *errors.RepositoryError) int {
+	switch err.Code {
+	case errors.DuplicateKey:
+		return http.StatusForbidden
+	case errors.Timeout:
+		return http.StatusRequestTimeout
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/server/src/utils/utils.go
+++ b/server/src/utils/utils.go
@@ -37,11 +37,6 @@ func GetRequestBody(bodyBuffer io.ReadCloser, result *map[string]interface{}) er
 	bodyBytes, _ := ioutil.ReadAll(bodyBuffer)
 	defer bodyBuffer.Close()
 
-	if len(bodyBytes) == 0 {
-		result = nil
-		return nil
-	}
-
 	err := json.Unmarshal(bodyBytes, result)
 
 	return err

--- a/server/src/utils/utils.go
+++ b/server/src/utils/utils.go
@@ -38,3 +38,13 @@ func GetRequestBody(bodyBuffer io.ReadCloser, result *map[string]interface{}) er
 
 	return err
 }
+
+func Remove(arr []string, value string) []string {
+	for i, v := range arr {
+		if v == value {
+			return append(arr[:i], arr[i+1:]...)
+		}
+	}
+
+	return arr
+}

--- a/server/tests/controllers/deck_controller_test.go
+++ b/server/tests/controllers/deck_controller_test.go
@@ -12,23 +12,11 @@ import (
 	"mime/multipart"
 
 	"server/src/models"
+	"server/src/utils"
 	"server/tests/repositories/mocks"
 	
 	"github.com/stretchr/testify/assert"
 )
-
-func TestDeleteDeck(t *testing.T) {
-	setup()
-
-	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/decks/%s", deckId), nil)
-	if err != nil {
-		t.FailNow()
-	}
-	
-	router.ServeHTTP(responseRecorder, request)
-
-	assert.Equal(t, http.StatusOK, responseRecorder.Code)
-}
 
 func TestPostDecks(t *testing.T) {
 	setup()
@@ -198,6 +186,8 @@ func TestCopyPrivateDeck(t *testing.T) {
 func TestPutDeckAddingImage(t *testing.T) {
 	setup()
 
+	os.Mkdir(utils.GetImagesFilePath() + "/" + deckId, 0755)
+
 	card := models.Card{
 		UUID: 		"batata",
 		FrontText: 	"Frente card",
@@ -328,4 +318,17 @@ func TestPutDeckRemovingImage(t *testing.T) {
 
 	assert.Empty(t, responseDeck.Cover)
 	assert.Empty(t, responseDeck.Cards[0].FrontImagePath)
+}
+
+func TestDeleteDeck(t *testing.T) {
+	setup()
+
+	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("/api/decks/%s", deckId), nil)
+	if err != nil {
+		t.FailNow()
+	}
+	
+	router.ServeHTTP(responseRecorder, request)
+
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
 }

--- a/server/tests/controllers/deck_controller_test.go
+++ b/server/tests/controllers/deck_controller_test.go
@@ -51,7 +51,6 @@ func TestPostDecks(t *testing.T) {
 			Cards:            cards,
 			LastModification: 1654638124,
 			IsPublic:         false,
-			UUID:             "testdeckid1",
 			Tags:			  []string{},
 		}
 	

--- a/server/tests/controllers/deck_reference_controller_test.go
+++ b/server/tests/controllers/deck_reference_controller_test.go
@@ -42,3 +42,43 @@ func TestReadAllDeckReference(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, decks)
 }
+
+func TestGetPublicDeck(t *testing.T) {
+	setup()
+
+	testePublicDeckId := "testtest123"
+	publicDeck := models.Deck {
+		Name: "Batata",
+		Description: "Batatinha quando nasce espalha rama ou esparrama?",
+		IsPublic: true,
+	}
+
+	repoRef, _ := deckReferenceRepository.(*repositories_mock.DeckReferenceRepositoryMock)
+	repoDeck, _ := deckRepository.(*repositories_mock.DeckRepositoryMock)
+
+	repoDeck.Decks[testePublicDeckId] = &publicDeck
+
+	repoRef.DeckReferences = []models.DeckReference{
+		models.DeckReference{
+			Description: 	"Batatinha quando nasce espalha rama ou esparrama?",
+			Name:          	"Batata",
+			NumberOfCards: 	24,
+			Author:         "Geraldinho",
+			UUID:			testePublicDeckId,
+		},
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "/api/decksReference/" + testePublicDeckId, nil)
+	if err != nil {
+		t.FailNow()
+	}
+
+	router.ServeHTTP(responseRecorder, request)
+
+	response, _ := io.ReadAll(responseRecorder.Body)
+	deckBytes, _:= json.Marshal(publicDeck)
+
+	assert.Equal(t, http.StatusOK, responseRecorder.Code)
+	assert.Nil(t, err)
+	assert.Equal(t, string(response), string(deckBytes))
+}


### PR DESCRIPTION
Muitas coisas foram feitas... As que me lembro agora:

### Backend
- Muitos ajustes por conta de falhas ou coisas que faltavam
- Nova rota de pegar baralho público `/decksReference/:id` : antes só tinha como pegar a referência, nunca o baralho todo (só se fosse dono do baralho)

### Frontend
- Repositórios de baralho, referência e usuário
- Api de baralho, referência e usuário

**obs**: Pra usar os serviços da api no repositório, veja o exemplo para `deckReferenceApi` abaixo
```dart
    final chopperClient = Api.createInstance();
    final service = chopperClient.getService<DeckReferenceApi>();
    final repo = DeckReferenceRepository(service);
```

Testei tudo escrevendo testes em dart, mas não comitei eles porque foram testes cagados.